### PR TITLE
icon text line break fix JP

### DIFF
--- a/src/scss/organisms/_lang-ja.scss
+++ b/src/scss/organisms/_lang-ja.scss
@@ -5,3 +5,7 @@
   font-style: normal;
   font-weight: 200;
 }
+
+.lang-ja .dit-list-reasons__item:last-child {
+    white-space: nowrap;
+}


### PR DESCRIPTION
Only targets Japanese language, and it makes sure text doesn't wrap so line break is in appropriate place